### PR TITLE
changed unowned to weak for unsafe situations

### DIFF
--- a/SwiftSH Example/ShellViewController.swift
+++ b/SwiftSH Example/ShellViewController.swift
@@ -53,7 +53,7 @@ class ShellViewController: UIViewController, SSHViewController {
                 self.authenticationChallenge = .byPassword(username: self.username, password: password)
             } else {
                 self.authenticationChallenge = .byKeyboardInteractive(username: self.username) { [unowned self] challenge in
-                    DispatchQueue.main.async {
+                    DispatchQueue.main.async { [unowned self] in
                         self.appendToTextView(challenge)
                         self.textView.isEditable = true
                     }

--- a/SwiftSH/Channel.swift
+++ b/SwiftSH/Channel.swift
@@ -104,11 +104,14 @@ open class SSHChannel<T: RawLibrary>: SSHSession<T> {
     }
     
     public override func disconnect(_ completion: (() -> ())?) {
-        self.queue.async {
-            self.close()
-            
-            super.disconnect(completion)
+        self.queue.async { [weak self] in
+            self?.close()
+            self?.disconnectThroughSuper(completion: completion)
         }
+    }
+
+    private func disconnectThroughSuper(completion: (() -> ())?) {
+        super.disconnect(completion)
     }
 
     // MARK: - Terminal
@@ -120,8 +123,8 @@ open class SSHChannel<T: RawLibrary>: SSHSession<T> {
     }
 
     public func setTerminalSize(width: UInt, height: UInt, completion: SSHCompletionBlock?) {
-        self.queue.async(completion: completion) {
-            guard let terminal = self.terminal else {
+        self.queue.async(completion: completion) { [weak self] in
+            guard let terminal = self?.terminal else {
                 throw SSHError.badUse
             }
 
@@ -132,10 +135,10 @@ open class SSHChannel<T: RawLibrary>: SSHSession<T> {
                 resizedTerminal.height = height
 
                 // Update the terminal size
-                try self.channel.setPseudoTerminalSize(resizedTerminal)
+                try self?.channel.setPseudoTerminalSize(resizedTerminal)
 
                 // Set the new terminal
-                self.terminal = resizedTerminal
+                self?.terminal = resizedTerminal
             }
         }
     }

--- a/SwiftSH/Queue.swift
+++ b/SwiftSH/Queue.swift
@@ -69,17 +69,17 @@ internal class Queue {
                 }
             }
         } else {
-            self.queue.async(execute: {
+            self.queue.async(execute: { [weak self] in
                 do {
                     try block()
                     if let completion = completion {
-                        self.callbackQueue.async(execute: {
+                        self?.callbackQueue.async(execute: {
                             completion(nil)
                         })
                     }
                 } catch let error {
                     if let completion = completion {
-                        self.callbackQueue.async(execute: {
+                        self?.callbackQueue.async(execute: {
                             completion(error)
                         })
                     }


### PR DESCRIPTION
Using unowned self in async calls or closures can cause crashes or memory leaks. This pull requests fixes most of those unowned self to use weak self, which is much safer in most situations. Hope it helps!

* changed unowned to weak for unsafe situations
* extract method tryToEstablishConnection() from Session