### PR TITLE
Add `return self` to methods with completion closure that already had…

### DIFF
--- a/SwiftSH/Channel.swift
+++ b/SwiftSH/Channel.swift
@@ -116,12 +116,10 @@ open class SSHChannel<T: RawLibrary>: SSHSession<T> {
     // MARK: - Terminal
     
     public func setTerminalSize(width: UInt, height: UInt) -> Self {
-        self.setTerminalSize(width: width, height: height, completion: nil)
-
-        return self
+        return self.setTerminalSize(width: width, height: height, completion: nil)
     }
 
-    public func setTerminalSize(width: UInt, height: UInt, completion: SSHCompletionBlock?) {
+    public func setTerminalSize(width: UInt, height: UInt, completion: SSHCompletionBlock?) -> Self {
         self.queue.async(completion: completion) {
             guard let terminal = self.terminal else {
                 throw SSHError.badUse
@@ -140,6 +138,7 @@ open class SSHChannel<T: RawLibrary>: SSHSession<T> {
                 self.terminal = resizedTerminal
             }
         }
+        return self
     }
 
 }

--- a/SwiftSH/SCP.swift
+++ b/SwiftSH/SCP.swift
@@ -28,12 +28,11 @@ public class SCPSession<T: RawLibrary>: SSHChannel<T> {
     // MARK: - Download
     
     public func download(_ from: String, to path: String) -> Self {
-        self.download(from, to: path, completion: nil)
-
-        return self
+        return self.download(from, to: path, completion: nil)
     }
 
-    public func download(_ from: String, to path: String, completion: SSHCompletionBlock?) {
+    @discardableResult
+    public func download(_ from: String, to path: String, completion: SSHCompletionBlock?) -> Self {
         if let stream = OutputStream(toFileAtPath: path, append: false) {
             self.download(from, to: stream, completion: completion)
         } else if let completion = completion {
@@ -41,22 +40,22 @@ public class SCPSession<T: RawLibrary>: SSHChannel<T> {
                 completion(SSHError.SCP.invalidPath)
             }
         }
-    }
-
-    
-    public func download(_ from: String, to stream: OutputStream) -> Self {
-        self.download(from, to: stream, completion: nil)
-
         return self
     }
 
-    public func download(_ from: String, to stream: OutputStream, completion: SSHCompletionBlock?) {
+    public func download(_ from: String, to stream: OutputStream) -> Self {
+        return self.download(from, to: stream, completion: nil)
+    }
+
+    @discardableResult
+    public func download(_ from: String, to stream: OutputStream, completion: SSHCompletionBlock?) -> Self {
         self.queue.async(completion: completion) {
             stream.open()
             defer {
                 stream.close()
             }
         }
+        return self
     }
 
     public func download(_ from: String, completion: @escaping ((Data?, Error?) -> Void)) {

--- a/SwiftSH/Session.swift
+++ b/SwiftSH/Session.swift
@@ -99,12 +99,11 @@ open class SSHSession<T: RawLibrary> {
     }
 
     public func connect() -> Self {
-        self.connect(nil)
-
-        return self
+        return connect(nil)
     }
 
-    public func connect(_ completion: SSHCompletionBlock?) {
+    @discardableResult
+    public func connect(_ completion: SSHCompletionBlock?) -> Self {
         self.queue.async(completion: completion) {
             defer {
                 if !self.connected {
@@ -220,6 +219,7 @@ open class SSHSession<T: RawLibrary> {
             }
             self.log.debug("Fingerprint is \(self.fingerprint)")
         }
+        return self
     }
 
     public func disconnect(_ completion: (() -> ())?) {
@@ -276,12 +276,11 @@ open class SSHSession<T: RawLibrary> {
     }
 
     public func authenticate(_ challenge: AuthenticationChallenge?) -> Self {
-        self.authenticate(challenge, completion: nil)
-
-        return self
+        return self.authenticate(challenge, completion: nil)
     }
 
-    public func authenticate(_ challenge: AuthenticationChallenge?, completion: SSHCompletionBlock?) {
+    @discardableResult
+    public func authenticate(_ challenge: AuthenticationChallenge?, completion: SSHCompletionBlock?) -> Self {
         self.queue.async(completion: completion) {
             guard let challenge = challenge, !self.authenticated else {
                 return
@@ -324,6 +323,7 @@ open class SSHSession<T: RawLibrary> {
                     try self.session.authenticateByPublicKeyFromMemory(username, password: password, publicKey: publicKey, privateKey: privateKey)
             }
         }
+        return self
     }
     
     public func checkFingerprint(_ callback: @escaping ([FingerprintHashType: String]) -> Bool) -> Self {

--- a/SwiftSH/Shell.swift
+++ b/SwiftSH/Shell.swift
@@ -70,12 +70,11 @@ public class SSHShell<T: RawLibrary>: SSHChannel<T> {
     // MARK: - Open/Close
 
     public func open() -> Self {
-        self.open(nil)
-
-        return self
+        return open(nil)
     }
 
-    public func open(_ completion: SSHCompletionBlock?) {
+    @discardableResult
+    public func open(_ completion: SSHCompletionBlock?) -> Self {
         self.queue.async(completion: completion) {
             // Open the channel
             try super.open()
@@ -223,6 +222,8 @@ public class SSHShell<T: RawLibrary>: SSHChannel<T> {
             
             self.log.debug("Shell opened successfully")
         }
+
+        return self
     }
 
     public func close(_ completion: (() -> ())?) {
@@ -267,12 +268,11 @@ public class SSHShell<T: RawLibrary>: SSHChannel<T> {
     // MARK: - Write
     
     public func write(_ data: Data) -> Self {
-        self.write(data, completion: nil)
-
-        return self
+        return self.write(data, completion: nil)
     }
 
-    public func write(_ data: Data, completion: ((Error?) -> Void)?) {
+    @discardableResult
+    public func write(_ data: Data, completion: ((Error?) -> Void)?) -> Self {
         self.queue.async {
             // Insert the message in the message queue
             let message = Message(data: data, callback: completion)
@@ -282,27 +282,32 @@ public class SSHShell<T: RawLibrary>: SSHChannel<T> {
             if let writeSource = self.writeSource, !self.messageQueue.isEmpty, !self.writing {
                 self.writing = true
                 writeSource.resume()
+            } else {
+
+                self.log.debug("Invalid Write Source for SSH Shell")
             }
         }
-    }
-
-    public func write(_ command: String) -> Self {
-        self.write(command, completion: nil)
-        
         return self
     }
 
-    public func write(_ command: String, completion: ((Error?) -> Void)?) {
+    public func write(_ command: String) -> Self {
+        return self.write(command, completion: nil)
+    }
+
+    @discardableResult
+    public func write(_ command: String, completion: ((Error?) -> Void)?) -> Self {
         guard let data = command.data(using: .utf8) else {
             if let completion = completion {
                 self.queue.callbackQueue.async {
                     completion(SSHError.invalid)
                 }
             }
-            return
+            return self
         }
         
         self.write(data, completion: completion)
+
+        return self
     }
 }
 


### PR DESCRIPTION
When adding a completion block to open/write/connect/download etc, I noticed the behaviour of chaining those commands is a little different. This fixes that problem, so adding a completion block to any of these method calls does not change other results.